### PR TITLE
Backport to python 3.6

### DIFF
--- a/fatbuildr/builds/__init__.py
+++ b/fatbuildr/builds/__init__.py
@@ -142,6 +142,21 @@ class ArtifactBuild(RunnableTask):
     def checksum_value(self):
         return self.defs.checksum_value(self.derivative)
 
+    @property
+    def tarball_in_build_place(self):
+        """Returns True if the artifact tarball is located in build place (ie.
+        the tarball was provided by the user within the build request), or False
+        otherwise.
+        This code does not call self.tarball.is_relative_to(self.place) method
+        because Fatbuildr supports Python 3.6+ and this method is only available
+        starting from Python 3.9.
+        """
+        try:
+            self.tarball.relative_to(self.place)
+            return True
+        except ValueError:
+            return False
+
     def patch_selected(self, patch):
         """Check in the patch metadata in deb822 format if is it restricted to
         specific distributions or formats and in this case, check if it can be

--- a/fatbuildr/builds/__init__.py
+++ b/fatbuildr/builds/__init__.py
@@ -23,6 +23,8 @@ import tarfile
 import stat
 from pathlib import Path
 from datetime import date
+from typing import List
+
 try:
     from functools import cached_property
 except ImportError:
@@ -63,7 +65,7 @@ class ArtifactBuild(RunnableTask):
     EXFIELDS = {
         ExportableTaskField('format'),
         ExportableTaskField('distribution'),
-        ExportableTaskField('architectures', list[str]),
+        ExportableTaskField('architectures', List[str]),
         ExportableTaskField('derivative'),
         ExportableTaskField('artifact'),
         ExportableTaskField('user'),

--- a/fatbuildr/builds/__init__.py
+++ b/fatbuildr/builds/__init__.py
@@ -23,7 +23,17 @@ import tarfile
 import stat
 from pathlib import Path
 from datetime import date
-from functools import cached_property
+try:
+    from functools import cached_property
+except ImportError:
+    # For Python 3.[6-7] compatibility. The dependency to cached_property
+    # external library is not declared in setup.py, it is added explicitely in
+    # packages codes only for distributions stuck with these old versions of
+    # Python.
+    #
+    # This try/except block can be removed when support of Python < 3.8 is
+    # dropped in Fatbuildr.
+    from cached_property import cached_property
 
 from ..protocols.exports import ExportableTaskField
 

--- a/fatbuildr/builds/formats/deb.py
+++ b/fatbuildr/builds/formats/deb.py
@@ -215,7 +215,7 @@ class ArtifactBuildDeb(ArtifactEnvBuild):
         # If the artifact tarball is the build place, create a relative symbolic
         # link, so the link stays valid when the task is moved in archives.
         # Otherwise (ie. the tarball is in cache), use the absolute path.
-        if self.tarball.is_relative_to(self.place):
+        if self.tarball_in_build_place:
             dest = self.tarball.relative_to(self.tarball.parent)
         else:
             dest = self.tarball

--- a/fatbuildr/builds/formats/rpm.py
+++ b/fatbuildr/builds/formats/rpm.py
@@ -266,7 +266,7 @@ class ArtifactBuildRpm(ArtifactEnvBuild):
         # Otherwise, move the tarball from the build place to the sources
         # subdirectory.
         source = self.source_path.joinpath(self.tarball.name)
-        if not self.tarball.is_relative_to(self.place):
+        if not self.tarball_in_build_place:
             logger.info("Creating symlink %s → %s", source, self.tarball)
             source.symlink_to(self.tarball)
         else:
@@ -292,7 +292,7 @@ class ArtifactBuildRpm(ArtifactEnvBuild):
         # If the source tarball is not in build place (ie. in cache),
         # bind-mount the tarball directory in mock environment so rpmbuild can
         # access to the target of the tarball symlink in build place.
-        if not self.tarball.is_relative_to(self.place):
+        if not self.tarball_in_build_place:
             cmd[3:3] = [
                 '--plugin-option',
                 "bind_mount:dirs="

--- a/fatbuildr/cli/fatbuildrctl.py
+++ b/fatbuildr/cli/fatbuildrctl.py
@@ -178,9 +178,19 @@ class Fatbuildrctl(FatbuildrCliRun):
             help=f"URI of Fatbuildr server (default: {DEFAULT_URI})",
         )
 
-        subparsers = parser.add_subparsers(
-            help='Action to perform', dest='action', required=True
-        )
+        # Unfortunately, Python 3.6 does support add_subparsers() required
+        # attribute. The requirement is later handled with a AttributeError on
+        # args.func to provide the same functionnal level.
+        # This Python version conditionnal test can be removed when support of
+        # Python 3.6 is dropped in Fatbuildr.
+        if sys.version_info[1] >= 3 and sys.version_info[1] >= 7:
+            subparsers = parser.add_subparsers(
+                help='Action to perform', dest='action', required=True
+            )
+        else:
+            subparsers = parser.add_subparsers(
+                help='Action to perform', dest='action'
+            )
 
         # Parser for the images command
         parser_images = subparsers.add_parser(
@@ -377,6 +387,9 @@ class Fatbuildrctl(FatbuildrCliRun):
         # permission error returned by fatbuildrd.
         try:
             args.func(args)
+        except AttributeError:
+            parser.print_usage()
+            logger.error("The action argument must be given")
         except PermissionError as err:
             logger.error("You are not authorized to %s", err)
             sys.exit(1)

--- a/fatbuildr/exec.py
+++ b/fatbuildr/exec.py
@@ -49,7 +49,11 @@ def runcmd(cmd, io=None, **kwargs):
 def _runcmd_noninteractive(cmd, io, **kwargs):
     logger.debug("Running command: %s", shelljoin(cmd))
     if io is None:
-        return subprocess.run(cmd, capture_output=True, **kwargs)
+        # Unfortunately, subprocess.run(capture_output=True) cannot be used
+        # because it is only available starting from Python 3.7 but Fatbuildr
+        # aims to support Python 3.6. The capture_output argument could be
+        # adopted when Python 3.6 support is dropped in Fatbuildr.
+        return subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs)
     else:
         return subprocess.run(
             cmd, stdout=io.output_w, stderr=io.output_w, **kwargs

--- a/fatbuildr/git.py
+++ b/fatbuildr/git.py
@@ -21,7 +21,19 @@ import subprocess
 import re
 from datetime import datetime
 from pathlib import Path
-from functools import cached_property
+
+try:
+    from functools import cached_property
+except ImportError:
+    # For Python 3.[6-7] compatibility. The dependency to cached_property
+    # external library is not declared in setup.py, it is added explicitely in
+    # packages codes only for distributions stuck with these old versions of
+    # Python.
+    #
+    # This try/except block can be removed when support of Python < 3.8 is
+    # dropped in Fatbuildr.
+    from cached_property import cached_property
+
 
 import pygit2
 from debian import deb822

--- a/fatbuildr/protocols/dbus/__init__.py
+++ b/fatbuildr/protocols/dbus/__init__.py
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Fatbuildr.  If not, see <https://www.gnu.org/licenses/>.
 
+import inspect
+
 from dasbus.connection import SystemMessageBus
 from dasbus.error import DBusError, ErrorMapper, get_error_decorator
 from dasbus.identifier import DBusServiceIdentifier, DBusInterfaceIdentifier
@@ -160,7 +162,9 @@ class FatbuildrDBusData:
                 field.wire_type is str and wire_value == '∅'
             ):
                 native_value = None
-            elif issubclass(field.wire_type, ExportableType):
+            elif inspect.isclass(field.wire_type) and issubclass(
+                field.wire_type, ExportableType
+            ):
                 # If the field has an exportable type, convert the structure to
                 # the corresponding FatbuildrNativeDBusData type.
                 native_value = dbus_type(
@@ -189,7 +193,9 @@ class FatbuildrDBusData:
                     wire_value = -1
                 else:
                     wire_value = '∅'
-            elif issubclass(field.wire_type, ExportableType):
+            elif inspect.isclass(field.wire_type) and issubclass(
+                field.wire_type, ExportableType
+            ):
                 # If the type is directly exportable on the wire, convert it
                 # to (nested) structure.
                 wire_value = dbus_type(field.wire_type.__name__).to_structure(
@@ -199,7 +205,9 @@ class FatbuildrDBusData:
                 wire_value = field.export(task)
 
             # If the type is exported, declare it as Structure type
-            if issubclass(field.wire_type, ExportableType):
+            if inspect.isclass(field.wire_type) and issubclass(
+                field.wire_type, ExportableType
+            ):
                 wire_type = Structure
             else:
                 wire_type = field.wire_type

--- a/fatbuildr/protocols/exports.py
+++ b/fatbuildr/protocols/exports.py
@@ -18,6 +18,7 @@
 # along with Fatbuildr.  If not, see <https://www.gnu.org/licenses/>.
 
 import types
+import inspect
 from datetime import datetime
 from pathlib import Path
 
@@ -50,7 +51,9 @@ class ExportableField:
             return int(value.timestamp())
         elif self.native_type is Path:
             return str(value)
-        elif issubclass(self.native_type, ExportableType):
+        elif inspect.isclass(self.native_type) and issubclass(
+            self.native_type, ExportableType
+        ):
             return value.export()
         return value
 
@@ -66,7 +69,9 @@ class ExportableField:
             return datetime.fromtimestamp(value)
         elif self.native_type is Path:
             return Path(value)
-        elif issubclass(self.native_type, ExportableType):
+        elif inspect.isclass(self.native_type) and issubclass(
+            self.native_type, ExportableType
+        ):
             return self.native_type(**value)
         return value
 

--- a/fatbuildr/protocols/http/__init__.py
+++ b/fatbuildr/protocols/http/__init__.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Fatbuildr.  If not, see <https://www.gnu.org/licenses/>.
 
+import inspect
 
 from ..wire import (
     WireData,
@@ -61,7 +62,9 @@ class JsonData:
         obj = cls()
         for field in fields:
             wire_value = json[field.name]
-            if issubclass(field.wire_type, ExportableType):
+            if inspect.isclass(field.wire_type) and issubclass(
+                field.wire_type, ExportableType
+            ):
                 # If the field has an exportable type, convert the JSON to
                 # the corresponding JsonNativeData type.
                 native_value = native_json_type(

--- a/fatbuildr/registry/formats/__init__.py
+++ b/fatbuildr/registry/formats/__init__.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Fatbuildr.  If not, see <https://www.gnu.org/licenses/>.
 
+from typing import List
 import re
 
 from ...specifics import ArchMap
@@ -129,7 +130,7 @@ class ChangelogEntry(ExportableType):
         ExportableField('version'),
         ExportableField('author'),
         ExportableField('date', int),
-        ExportableField('changes', list[str]),
+        ExportableField('changes', List[str]),
     }
 
     def __init__(self, version, author, date, changes):

--- a/fatbuildr/utils.py
+++ b/fatbuildr/utils.py
@@ -69,7 +69,10 @@ def verify_checksum(path, format, value):
     f_hash = hasher(format)
 
     with open(path, "rb") as fh:
-        while chunk := fh.read(8192):
+        while True:
+            chunk = fh.read(8192)
+            if not chunk:
+                break
             f_hash.update(chunk)
 
     if f_hash.hexdigest() != value:


### PR DESCRIPTION
This PR contains some code modifications to add support for Python starting from version 3.6+. This brings some unpleasant code smells compared to the current code based but they are flagged and code comments provide the documentation to remove these flaws.

Closes #9