### PR TITLE
Automatically exclude files untracked by git in generated source archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     API (#141)
   - Possibility to remove artifacts from registries in remote instance with the
     REST API (#142)
+  - Add `--include-git-untracked` option to `build` and `patches` commands to
+    avoid automatic exclusion from generated archive of files untracked by git
+    in local source tree.
 - web: Report fatbuildr version in footer of fatbuildrweb HTML pages (#108).
 - api:
   - Add _edit-registry_ permission action.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     tokens of prescript rules.
   - Mention possibility to install DNF modules as prescript dependencies with
     `module:` prefix.
+  - Mention new `--include-git-untracked` option for `build` and `patches`
+    commands in `fatbuildrctl` manpage.
 
 ### Changed
 - docs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   definition of different values for different distributions and formats (#156).
 - Support installation of DNF modules as prescript dependencies for RPM packages
   builds (#155).
+- Automatically exclude from generated archive files untracked by git (ex:
+  referenced in `.gitignore`) when building or managing patches from local
+  source tree with initialized git repository (#153).
 - cli:
   - Possibility to list artifacts in registries in remote instance with the REST
     API (#141)

--- a/docs/modules/usage/pages/fatbuildrctl.adoc
+++ b/docs/modules/usage/pages/fatbuildrctl.adoc
@@ -90,6 +90,11 @@ This command accepts the following options:
   directory instead of using the source tarball from the URL declared in
   artifact definition. See <<man-src,*LOCAL SOURCES*>> section for more details.
 
+*--include-git-untracked*::
+  Include in artifact source archive generated from local source directory files
+  that are untracked in git repository. This option only has effect with
+  *--sources* option. See <<man-src,*LOCAL SOURCES*>> section for more details.
+
 *-n, --name*=_NAME_::
   User name for artifact build changelog entry. This option is required, unless
   the user name is defined in user preferences file (see
@@ -409,6 +414,11 @@ This command accepts the following options:
   directory instead of using the source tarball from the URL declared in
   artifact definition. See <<man-src,*LOCAL SOURCES*>> section for more details.
 
+*--include-git-untracked*::
+  Include in artifact source archive generated from local source directory files
+  that are untracked in git repository.  This option only has effect with
+  *--sources* option. See <<man-src,*LOCAL SOURCES*>> section for more details.
+
 *-n, --name*=_NAME_::
   User name for temporary Git repository initial commit author and commiter.
   This option is required, unless the user name is defined in user preferences
@@ -611,6 +621,14 @@ once.
   `~/path/to/code` and version `1.2.3`, and generate archive for artifact
   _other_ source with the content of directory `~/path/to/other-code` and
   version `4.5.6`.
+
+Some files are automatically excluded by Fatbuildr from the generated archives:
+
+* All files whose name start by `.git` (_ex:_ `.gitignore` and `.git/` folder),
+* The `debian/` subdirectory recursively,
+* If the source tree is an initialized Git repository, all files referenced as
+  untracked in this repository (typically in `.gitignore`). This can be disabled
+  with **--include-git-untracked** option.
 
 [[man-pref]]
 == Preferences file

--- a/fatbuildr/git.py
+++ b/fatbuildr/git.py
@@ -53,6 +53,10 @@ def is_meta_generic(meta):
     return 'Generic' in meta and meta['Generic'] == 'yes'
 
 
+def load_git_repository(path: str):
+    return pygit2.Repository(path)
+
+
 # It is not possible to inherit directory from pathlib.Path as this class
 # constructor actually returns the specialized type according to the underlying
 # OS. One solution is to discover the actual specialized type for the current OS


### PR DESCRIPTION
fix #153