### PR TITLE
Add `rpm_version` template filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `/etc/group` and `/etc/gshadow`.
 - pkgs: Install and enable AppArmor profile for `u-nspawn` on systems that
   support this LSM.
-- docs: Mention `img_create_use_sysusersd` parameter in `[format:*]` sections of
-  system configuration.
+- docs:
+  - Mention `img_create_use_sysusersd` parameter in `[format:*]` sections of
+    system configuration.
+  - Mention template filters `timestamp_rpmdate` and `timestamp_iso` in artifact
+    definition reference documentation.
 
 ### Changed
 - Use uncompressed skeleton archive to bootstrap _fatbuildr_ system user in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - docs:
   - Mention `img_create_use_sysusersd` parameter in `[format:*]` sections of
     system configuration.
-  - Mention template filters `timestamp_rpmdate` and `timestamp_iso` in artifact
-    definition reference documentation.
+  - Mention template filters `timestamp_rpmdate`, `timestamp_iso` and
+    `rpm_version` in artifact definition reference documentation.
 
 ### Changed
 - Use uncompressed skeleton archive to bootstrap _fatbuildr_ system user in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `SyntaxWarning` on regexp raised by Python 3.12 on in utils module (#201).
 - Replace calls to `shlex.join()` by `shlex_join()` backport provided by
   rfl.core external library (#199).
+- Add template filter `rpm_version` designed to replace illegal character `-` by
+  `~` in RPM spec `Version` field (#210).
 - web: Send `*.xml.gz` files in repositories with `application/zip` mimetype to
   fool aiohttp library and workaround Pulp and Red Hat Satellite synchronization
   checksum mismatch error (#194).

--- a/docs/modules/usage/pages/repo.adoc
+++ b/docs/modules/usage/pages/repo.adoc
@@ -739,6 +739,12 @@ in tarball URL.
 
 _Ex:_ `1.2.3~beta1` → `1.2.3-beta1`
 
+|`rpm_version`
+| Replace in a string illegal characters in RPM spec Version field. More
+specifically, it replaces `-` by `~`.
+
+_Ex:_ `1.2-0rc1` → `1.2~0rc1`
+
 |`timestamp_rpmdate`
 | Transform an integer timestamp into a date formatted as expected for RPM spec
 changelog.

--- a/docs/modules/usage/pages/repo.adoc
+++ b/docs/modules/usage/pages/repo.adoc
@@ -732,11 +732,22 @@ templates:
 |Name|Description
 
 |`gittag`
-| It replaces in a string characters disallowed in Git tags. For reference, see
+| Replace in a string characters disallowed in Git tags. For reference, see
 https://git-scm.com/docs/git-check-ref-format[`git check-ref-format` manpage].
 It is notably useful to transform a complex version number into a valid Git tag
 in tarball URL.
 
 _Ex:_ `1.2.3~beta1` → `1.2.3-beta1`
+
+|`timestamp_rpmdate`
+| Transform an integer timestamp into a date formatted as expected for RPM spec
+changelog.
+
+_Ex:_ `949547106` → `Thu Feb 03 2000`
+
+|`timestamp_iso`
+| Transform an integer timestamp into a date in ISO format.
+
+_Ex:_ `949547106` → `2000-02-03 04:05:06`
 
 |===

--- a/fatbuildr/builds/formats/rpm.py
+++ b/fatbuildr/builds/formats/rpm.py
@@ -75,12 +75,6 @@ PATCHES_PREP_TPL = """
 """
 
 
-# Jinja2 filter to convert timestamp to date formatted for RPM spec file
-# changelog entries.
-def timestamp_rpmdate(value):
-    return datetime.fromtimestamp(value).strftime("%a %b %d %Y")
-
-
 class ArtifactBuildRpm(ArtifactEnvBuild):
     """Class to manipulation package in RPM format."""
 
@@ -256,7 +250,6 @@ class ArtifactBuildRpm(ArtifactEnvBuild):
             new_changelog.extend(existing_changelog)
 
         # Render changelog based on string template
-        templater.env.filters["timestamp_rpmdate"] = timestamp_rpmdate
         changelog = templater.srender(CHANGELOG_TPL, changelog=new_changelog)
 
         # Generate spec file based on template

--- a/fatbuildr/builds/formats/rpm.py
+++ b/fatbuildr/builds/formats/rpm.py
@@ -118,13 +118,10 @@ class ArtifactBuildRpm(ArtifactEnvBuild):
     def spec_basename(self):
         return self.artifact + '.spec'
 
-    @property
-    def srpm_filename(self):
-        return self.artifact + '-' + self.version.full + '.src.rpm'
-
-    @property
     def srpm_path(self):
-        return self.place.joinpath(self.srpm_filename)
+        """Return first *.src.rpm found in build place."""
+        for srpm in self.place.glob(f"{self.artifact}-*.src.rpm"):
+            return srpm
 
     @property
     def source_path(self):
@@ -342,7 +339,7 @@ class ArtifactBuildRpm(ArtifactEnvBuild):
         )
         logger.info(
             "Building binary RPM based on %s in build environment %s",
-            self.srpm_path,
+            self.srpm_path(),
             env,
         )
 
@@ -372,7 +369,7 @@ class ArtifactBuildRpm(ArtifactEnvBuild):
             '--resultdir',
             self.place,
             '--rebuild',
-            self.srpm_path,
+            self.srpm_path(),
         ]
 
         # Add additional build args if defined

--- a/fatbuildr/protocols/http/server/__init__.py
+++ b/fatbuildr/protocols/http/server/__init__.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Fatbuildr.  If not, see <https://www.gnu.org/licenses/>.
 
-from datetime import datetime
 from pathlib import Path
 
 from flask import Flask
@@ -27,14 +26,11 @@ from jinja2 import FileSystemLoader
 from . import views
 from .policy import PolicyManager
 from ....tokens import TokensManager
+from ....templates import register_filters
 from ....errors import FatbuildrRuntimeError, FatbuildrServerInstanceError
 from ....log import logr
 
 logger = logr(__name__)
-
-
-def timestamp_iso(value):
-    return datetime.fromtimestamp(value).isoformat(sep=' ', timespec='seconds')
 
 
 class WebApp(Flask):
@@ -176,7 +172,7 @@ class WebApp(Flask):
         self.register_error_handler(403, views.error_forbidden)
         self.register_error_handler(404, views.error_not_found)
 
-        self.jinja_env.filters['timestamp_iso'] = timestamp_iso
+        register_filters(self.jinja_env)
         self.config['UPLOAD_FOLDER'] = Path('/run/fatbuildr')
         self.config['REGISTRY_FOLDER'] = self.conf.dirs.registry
         self.config['INSTANCE'] = self.instance

--- a/fatbuildr/templates.py
+++ b/fatbuildr/templates.py
@@ -36,6 +36,9 @@ def filter_gittag(value):
     composed of the Git tag."""
     return value.replace('~', '-')
 
+def filter_rpm_version(value):
+    """Filter to replace characters not authorized in RPM version."""
+    return value.replace('-', '~')
 
 def timestamp_rpmdate(value):
     """Filter to convert timestamp to date formatted for RPM spec file changelog
@@ -50,6 +53,7 @@ def timestamp_iso(value):
 
 def register_filters(env):
     env.filters['gittag'] = filter_gittag
+    env.filters['rpm_version'] = filter_rpm_version
     env.filters['timestamp_rpmdate'] = timestamp_rpmdate
     env.filters['timestamp_iso'] = timestamp_iso
 

--- a/fatbuildr/templates.py
+++ b/fatbuildr/templates.py
@@ -17,11 +17,17 @@
 # You should have received a copy of the GNU General Public License
 # along with Fatbuildr.  If not, see <https://www.gnu.org/licenses/>.
 
+from datetime import datetime
+
 import jinja2
 
 from .log import logr
 
 logger = logr(__name__)
+
+#
+# Custom Jinja2 filters
+#
 
 
 def filter_gittag(value):
@@ -29,6 +35,23 @@ def filter_gittag(value):
     especially usefull for versions numbers in tarballs URL when the URL is
     composed of the Git tag."""
     return value.replace('~', '-')
+
+
+def timestamp_rpmdate(value):
+    """Filter to convert timestamp to date formatted for RPM spec file changelog
+    entries."""
+    return datetime.fromtimestamp(value).strftime("%a %b %d %Y")
+
+
+def timestamp_iso(value):
+    """Filter to convert timestamp to date formatted in ISO format."""
+    return datetime.fromtimestamp(value).isoformat(sep=' ', timespec='seconds')
+
+
+def register_filters(env):
+    env.filters['gittag'] = filter_gittag
+    env.filters['timestamp_rpmdate'] = timestamp_rpmdate
+    env.filters['timestamp_iso'] = timestamp_iso
 
 
 class Templeter:
@@ -42,7 +65,7 @@ class Templeter:
         self.env = jinja2.Environment(
             trim_blocks=True, lstrip_blocks=True, keep_trailing_newline=True
         )
-        self.env.filters['gittag'] = filter_gittag
+        register_filters(self.env)
 
     def srender(self, str, **kwargs):
         """Render a string template."""

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 Rackslab
+#
+# This file is part of Fatbuildr.
+#
+# Fatbuildr is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Fatbuildr is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Fatbuildr.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+import textwrap
+from datetime import datetime
+
+from fatbuildr.templates import Templeter
+
+
+class TestTempleter(unittest.TestCase):
+    def setUp(self):
+        self.templeter = Templeter()
+
+    def test_srender(self):
+        self.assertEqual(
+            self.templeter.srender(
+                textwrap.dedent(
+                    """
+                    text
+                    {{ key }} = {{ value }}
+                    """
+                ),
+                key="test",
+                value="running",
+            ),
+            textwrap.dedent(
+                """
+                text
+                test = running
+                """
+            ),
+        )
+
+    def test_filter_gittag(self):
+        self.assertEqual(
+            self.templeter.srender(
+                "{{ version | gittag }}", version="1.2-0~rc1"
+            ),
+            "1.2-0-rc1",
+        )
+
+    def test_filter_timestamp_rpmdate(self):
+        self.assertEqual(
+            self.templeter.srender(
+                "{{ timestamp | timestamp_rpmdate }}",
+                timestamp=datetime.timestamp(datetime(2000, 2, 3)),
+            ),
+            "Thu Feb 03 2000",
+        )
+
+    def test_filter_timestamp_iso(self):
+        self.assertEqual(
+            self.templeter.srender(
+                "{{ timestamp | timestamp_iso }}",
+                timestamp=datetime.timestamp(datetime(2000, 2, 3, 4, 5, 6)),
+            ),
+            "2000-02-03 04:05:06",
+        )

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -56,6 +56,14 @@ class TestTempleter(unittest.TestCase):
             "1.2-0-rc1",
         )
 
+    def test_filter_rpm_version(self):
+        self.assertEqual(
+            self.templeter.srender(
+                "{{ version | rpm_version }}", version="1.2-0rc1"
+            ),
+            "1.2~0rc1",
+        )
+
     def test_filter_timestamp_rpmdate(self):
         self.assertEqual(
             self.templeter.srender(


### PR DESCRIPTION
Designed to replace illegal character in RPM version Version field.

fix #210