### PR TITLE
feat: support building openSUSE OSI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `systemd-nspawn` and some packages build utilities in restricted sandboxes.
 - Add AppArmor profile for `fatbuildrd` to run `mkosi` in unconfined sandboxes
   without transition to default `unprivileged_userns` profile.
-- conf: Add `img_create_use_sysusersd` boolean parameter in `[format:*]` section
-  to control if _fatbuildr_ system user is created with `sysusers.d`
-  configuration file during image creation or with raw seeds of `/etc/passwd`,
-  `/etc/group` and `/etc/gshadow`.
+- Add support to build opensuse OSI images (#222).
+- conf:
+  - Add `img_create_use_sysusersd` boolean parameter in `[format:*]` section
+    to control if _fatbuildr_ system user is created with `sysusers.d`
+    configuration file during image creation or with raw seeds of `/etc/passwd`,
+    `/etc/group` and `/etc/gshadow`.
+  - Add `zypper` and `distribution-gpg-keys` in OSI image to support building
+    openSUSE.
 - pkgs: Install and enable AppArmor profile for `u-nspawn` on systems that
   support this LSM.
 - docs:

--- a/conf/images/osi.mkosi
+++ b/conf/images/osi.mkosi
@@ -19,6 +19,7 @@ Packages=
   diffutils
   cpio
   debootstrap
+  distribution-gpg-keys
   systemd-udev
   systemd-container
   systemd-ukify
@@ -32,4 +33,5 @@ Packages=
   edk2-ovmf
   sbsigntools
   man-db
+  zypper
 PostInstallationScripts=/usr/share/fatbuildr/images/scripts/osi-postinstall.sh


### PR DESCRIPTION
Add zypper and distribution-gpg-keys packages in OSI format image in order to support building openSUSE images.

Pending tasks for full support:

- [ ] Submit patch for mkosi fix
- [x] Submit patch for distribution-gpg-keys: https://github.com/rpm-software-management/distribution-gpg-keys/pull/148

fix #222